### PR TITLE
feat: implement contest tournament

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="liberica-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21 (3)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         </dependency>
 
 
+
     </dependencies>
 
     <build>

--- a/src/main/java/bot/CodeforcesBot.java
+++ b/src/main/java/bot/CodeforcesBot.java
@@ -1,5 +1,7 @@
 package bot;
 
+import bot.api.CodeforcesApiCaller;
+import bot.listener.ContestTimerHandler;
 import bot.listener.DiscordEventListener;
 import net.dv8tion.jda.api.sharding.DefaultShardManagerBuilder;
 import net.dv8tion.jda.api.sharding.ShardManager;
@@ -26,7 +28,8 @@ public class CodeforcesBot {
     @NotNull
     private ShardManager buildShardManager(String token) throws LoginException {
         DefaultShardManagerBuilder builder = DefaultShardManagerBuilder.createDefault(token)
-                .addEventListeners(new DiscordEventListener(this));
+                .addEventListeners(new DiscordEventListener(this))
+                .addEventListeners(new ContestTimerHandler(new CodeforcesApiCaller()));
 
         return builder.build();
     }

--- a/src/main/java/bot/api/CodeforcesAPI.java
+++ b/src/main/java/bot/api/CodeforcesAPI.java
@@ -3,8 +3,10 @@ package bot.api;
 
 import bot.domain.user.Rating;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 
 import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public interface CodeforcesAPI {
@@ -25,4 +27,7 @@ public interface CodeforcesAPI {
 
     // Get a random problem
     EmbedBuilder getRandomProblem(List<String> tagsList, int rateStart, int rateEnd) throws IOException;
+
+    // Get a random contest
+    EmbedBuilder getRandomContest(SlashCommandInteractionEvent event, List<String> usernames, String contestType, ZonedDateTime startTime, ZonedDateTime userTime) throws IOException;
 }

--- a/src/main/java/bot/commands/CommandFactory.java
+++ b/src/main/java/bot/commands/CommandFactory.java
@@ -1,6 +1,7 @@
 package bot.commands;
 
 import bot.commands.contestCommands.FinishedContestsCommand;
+import bot.commands.contestCommands.RandomContestCommand;
 import bot.commands.contestCommands.StandingCommand;
 import bot.commands.contestCommands.UpcomingContestsCommand;
 import bot.commands.problemCommands.RandomProblemCommand;
@@ -37,6 +38,8 @@ public class CommandFactory {
         // random problem
         register("random-problem", new RandomProblemCommand());
 
+        // return random contest, none of the given usernames have participated in
+        register("random-contest", new RandomContestCommand());
     }
 
     public static void register(String name, Command command) {
@@ -66,7 +69,12 @@ public class CommandFactory {
                 Commands.slash("random-problem", "Get a random problem")
                         .addOption(STRING, "rating_start", "Rating start", true)
                         .addOption(STRING, "rating_end", "Rating end", true)
-                        .addOption(STRING, "tags", "Problem tags(separated by comma)", false)
+                        .addOption(STRING, "tags", "Problem tags(separated by comma)", false),
+
+                Commands.slash("random-contest", "Get a random contest")
+                        .addOption(STRING, "usernames", "Usernames(separated by comma)", true)
+                        .addOption(STRING, "contest_type", "Contest type (\"div1\", \"div2\", \"div3\", \"div4\")", true)
+                        .addOption(STRING, "start_time", "Start time (24 hour format) (e.g., 2023-10-01 15:00:00 +03:00)", true)
         ).queue();
     }
 }

--- a/src/main/java/bot/commands/contestCommands/RandomContestCommand.java
+++ b/src/main/java/bot/commands/contestCommands/RandomContestCommand.java
@@ -1,0 +1,117 @@
+package bot.commands.contestCommands;
+
+import bot.api.CodeforcesApiCaller;
+import bot.commands.Command;
+import bot.infrastructure.CodeforcesAPIImpl;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+public class RandomContestCommand implements Command {
+    private final CodeforcesAPIImpl codeforcesAPI;
+
+    public RandomContestCommand() {
+        this.codeforcesAPI = new CodeforcesAPIImpl(new CodeforcesApiCaller());
+    }
+
+    @Override
+    public void execute(@NotNull SlashCommandInteractionEvent event) {
+
+        // Log the user who used the command
+        Logger logger = LoggerFactory.getLogger(RandomContestCommand.class);
+        logger.info("Command used by: {}\nMessage: {}", event.getUser().getName(), event.getOptions());
+
+        // Defer the reply
+        event.deferReply(true).queue();
+
+        String usernames = Objects.requireNonNull(event.getOption("usernames")).getAsString();
+        String contestType = Objects.requireNonNull(event.getOption("contest_type")).getAsString();
+        String startTime = Objects.requireNonNull(event.getOption("start_time")).getAsString();
+
+        // Convert usernames to list
+        List<String> usernamesList = new ArrayList<>(List.of(usernames.split(",")));
+        usernamesList.replaceAll(String::trim);
+
+        InteractionHook hook = event.getHook();
+
+        ZonedDateTime startTimeZoned;
+        ZonedDateTime userTime;
+        try {
+            startTimeZoned = (ZonedDateTime) convertTime(startTime)[1];
+            userTime = (ZonedDateTime) convertTime(startTime)[0];
+        } catch (IllegalArgumentException e) {
+            hook.sendMessage("Error: " + e.getMessage()).queue();
+            return;
+        }
+
+        Button confirmButton = Button.success("confirm_contest", "Confirm");
+        Button cancelButton = Button.danger("cancel_contest", "Cancel");
+
+        CompletableFuture.supplyAsync(() -> {
+            try {
+                return codeforcesAPI.getRandomContest(event, usernamesList, contestType, startTimeZoned, userTime);
+
+            } catch (IOException e) {
+                hook.sendMessage("Error: " + e.getMessage()).queue();
+            }
+            return null;
+        }).thenAccept(embedBuilder ->
+                        hook.sendMessageEmbeds(embedBuilder.build())
+                                .setActionRow(confirmButton, cancelButton)
+                                .setEphemeral(true)
+                                .queue()
+        ).exceptionally(throwable -> {
+            hook.sendMessage("Error: " + throwable.getCause().getMessage()).queue();
+            return null;
+        });
+    }
+
+
+    @NotNull
+    @Contract(pure = true)
+    private Object[] convertTime(String contestStartTime) {
+        DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+                .appendPattern("yyyy-MM-dd HH:mm:ss")  // Date and time pattern
+                .optionalStart()
+                .appendLiteral(' ')                    // Space between date-time and timezone
+                .optionalEnd()
+                .optionalStart()                       // Start optional block for 'GMT', 'UTC', or other timezones
+                .appendZoneText(TextStyle.SHORT)       // Short timezone name (e.g., 'GMT', 'UTC')
+                .optionalEnd()
+                .optionalStart()
+                .appendPattern("XXX")                  // Handle offsets like +03:00, -05:00, etc.
+                .optionalEnd()
+                .optionalStart()
+                .appendPattern("Z")                    // Handle simple offsets like +0300, -0500, etc.
+                .optionalEnd()
+                .toFormatter();
+
+        Logger logger = LoggerFactory.getLogger(RandomContestCommand.class);
+
+        try {
+            ZonedDateTime zonedDateTime = ZonedDateTime.parse(contestStartTime, formatter);
+            ZonedDateTime localTime = zonedDateTime.withZoneSameInstant(ZoneId.systemDefault()); // Convert to system default timezone
+            logger.info("Input time: {}\nConverted time: {}", contestStartTime, localTime);
+            return new Object[]{zonedDateTime, localTime};
+        } catch (DateTimeParseException e) {
+            logger.error("Failed to parse date-time: {}", contestStartTime, e);
+            throw new IllegalArgumentException("Invalid date-time format. Please use the format: yyyy-MM-dd HH:mm:ss z or an appropriate offset.");
+        }
+    }
+}

--- a/src/main/java/bot/domain/contest/Contest.java
+++ b/src/main/java/bot/domain/contest/Contest.java
@@ -86,4 +86,18 @@ public class Contest {
     public void setRelativeTimeSeconds(int relativeTimeSeconds) {
         this.relativeTimeSeconds = relativeTimeSeconds;
     }
+
+    @Override
+    public String toString() {
+        return "Contest{" +
+               "id=" + id +
+               ", name='" + name + '\'' +
+               ", type='" + type + '\'' +
+               ", phase='" + phase + '\'' +
+               ", frozen=" + frozen +
+               ", durationSeconds=" + durationSeconds +
+               ", startTimeSeconds=" + startTimeSeconds +
+               ", relativeTimeSeconds=" + relativeTimeSeconds +
+               '}';
+    }
 }

--- a/src/main/java/bot/domain/contest/Party.java
+++ b/src/main/java/bot/domain/contest/Party.java
@@ -1,0 +1,78 @@
+package bot.domain.contest;
+
+import java.util.List;
+
+public class Party {
+    private Integer contestId; // Can be absent
+    private List<Member> members;
+    private String participantType;
+    private boolean ghost;
+    private long startTimeSeconds;
+
+    // Inner class for Member
+    public static class Member {
+        private String handle;
+
+        public Member(String handle) {
+            this.handle = handle;
+        }
+
+        public String getHandle() {
+            return handle;
+        }
+
+        public void setHandle(String handle) {
+            this.handle = handle;
+        }
+    }
+
+    // Constructor
+    public Party(Integer contestId, List<Member> members, String participantType, boolean ghost, long startTimeSeconds) {
+        this.contestId = contestId;
+        this.members = members;
+        this.participantType = participantType;
+        this.ghost = ghost;
+        this.startTimeSeconds = startTimeSeconds;
+    }
+
+    // Getters and Setters
+    public Integer getContestId() {
+        return contestId;
+    }
+
+    public void setContestId(Integer contestId) {
+        this.contestId = contestId;
+    }
+
+    public List<Member> getMembers() {
+        return members;
+    }
+
+    public void setMembers(List<Member> members) {
+        this.members = members;
+    }
+
+    public String getParticipantType() {
+        return participantType;
+    }
+
+    public void setParticipantType(String participantType) {
+        this.participantType = participantType;
+    }
+
+    public boolean isGhost() {
+        return ghost;
+    }
+
+    public void setGhost(boolean ghost) {
+        this.ghost = ghost;
+    }
+
+    public long getStartTimeSeconds() {
+        return startTimeSeconds;
+    }
+
+    public void setStartTimeSeconds(long startTimeSeconds) {
+        this.startTimeSeconds = startTimeSeconds;
+    }
+}

--- a/src/main/java/bot/domain/user/Submission.java
+++ b/src/main/java/bot/domain/user/Submission.java
@@ -1,0 +1,180 @@
+package bot.domain.user;
+
+import bot.domain.contest.Party;
+import bot.domain.contest.Problem;
+
+
+public class Submission {
+    private long id;
+    private Integer contestId; // Can be absent
+    private long creationTimeSeconds;
+    private int relativeTimeSeconds;
+    private Problem problem;
+    private Party author;
+    private String programmingLanguage;
+    private Verdict verdict; // Can be absent
+    private Testset testset;
+    private int passedTestCount;
+    private int timeConsumedMillis;
+    private long memoryConsumedBytes;
+    private Float points; // Can be absent
+
+    @Override
+    public String toString() {
+        return "Submission{" +
+               "id=" + id +
+               ", contestId=" + contestId +
+               ", creationTimeSeconds=" + creationTimeSeconds +
+               ", relativeTimeSeconds=" + relativeTimeSeconds +
+               ", problem=" + problem +
+               ", author=" + author +
+               ", programmingLanguage='" + programmingLanguage + '\'' +
+               ", verdict=" + verdict +
+               ", testset=" + testset +
+               ", passedTestCount=" + passedTestCount +
+               ", timeConsumedMillis=" + timeConsumedMillis +
+               ", memoryConsumedBytes=" + memoryConsumedBytes +
+               ", points=" + points +
+               '}';
+    }
+
+    // Enum for Verdict
+    public enum Verdict {
+        FAILED, OK, PARTIAL, COMPILATION_ERROR, RUNTIME_ERROR, WRONG_ANSWER, PRESENTATION_ERROR,
+        TIME_LIMIT_EXCEEDED, MEMORY_LIMIT_EXCEEDED, IDLENESS_LIMIT_EXCEEDED, SECURITY_VIOLATED,
+        CRASHED, INPUT_PREPARATION_CRASHED, CHALLENGED, SKIPPED, TESTING, REJECTED
+    }
+
+    // Enum for Testset
+    public enum Testset {
+        SAMPLES, PRETESTS, TESTS, CHALLENGES, TESTS1, TESTS2, TESTS3, TESTS4, TESTS5,
+        TESTS6, TESTS7, TESTS8, TESTS9, TESTS10
+    }
+
+    // Constructor
+    public Submission(long id, Integer contestId, long creationTimeSeconds, int relativeTimeSeconds,
+                      Problem problem, Party author, String programmingLanguage, Verdict verdict,
+                      Testset testset, int passedTestCount, int timeConsumedMillis,
+                      long memoryConsumedBytes, Float points) {
+        this.id = id;
+        this.contestId = contestId;
+        this.creationTimeSeconds = creationTimeSeconds;
+        this.relativeTimeSeconds = relativeTimeSeconds;
+        this.problem = problem;
+        this.author = author;
+        this.programmingLanguage = programmingLanguage;
+        this.verdict = verdict;
+        this.testset = testset;
+        this.passedTestCount = passedTestCount;
+        this.timeConsumedMillis = timeConsumedMillis;
+        this.memoryConsumedBytes = memoryConsumedBytes;
+        this.points = points;
+    }
+
+    // Getters and Setters
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public Integer getContestId() {
+        return contestId;
+    }
+
+    public void setContestId(Integer contestId) {
+        this.contestId = contestId;
+    }
+
+    public long getCreationTimeSeconds() {
+        return creationTimeSeconds;
+    }
+
+    public void setCreationTimeSeconds(long creationTimeSeconds) {
+        this.creationTimeSeconds = creationTimeSeconds;
+    }
+
+    public int getRelativeTimeSeconds() {
+        return relativeTimeSeconds;
+    }
+
+    public void setRelativeTimeSeconds(int relativeTimeSeconds) {
+        this.relativeTimeSeconds = relativeTimeSeconds;
+    }
+
+    public Problem getProblem() {
+        return problem;
+    }
+
+    public void setProblem(Problem problem) {
+        this.problem = problem;
+    }
+
+    public Party getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(Party author) {
+        this.author = author;
+    }
+
+    public String getProgrammingLanguage() {
+        return programmingLanguage;
+    }
+
+    public void setProgrammingLanguage(String programmingLanguage) {
+        this.programmingLanguage = programmingLanguage;
+    }
+
+    public Verdict getVerdict() {
+        return verdict;
+    }
+
+    public void setVerdict(Verdict verdict) {
+        this.verdict = verdict;
+    }
+
+    public Testset getTestset() {
+        return testset;
+    }
+
+    public void setTestset(Testset testset) {
+        this.testset = testset;
+    }
+
+    public int getPassedTestCount() {
+        return passedTestCount;
+    }
+
+    public void setPassedTestCount(int passedTestCount) {
+        this.passedTestCount = passedTestCount;
+    }
+
+    public int getTimeConsumedMillis() {
+        return timeConsumedMillis;
+    }
+
+    public void setTimeConsumedMillis(int timeConsumedMillis) {
+        this.timeConsumedMillis = timeConsumedMillis;
+    }
+
+    public long getMemoryConsumedBytes() {
+        return memoryConsumedBytes;
+    }
+
+    public void setMemoryConsumedBytes(long memoryConsumedBytes) {
+        this.memoryConsumedBytes = memoryConsumedBytes;
+    }
+
+    public Float getPoints() {
+        return points;
+    }
+
+    public void setPoints(Float points) {
+        this.points = points;
+    }
+
+
+}

--- a/src/main/java/bot/listener/ContestTimerHandler.java
+++ b/src/main/java/bot/listener/ContestTimerHandler.java
@@ -1,0 +1,290 @@
+package bot.listener;
+
+import bot.api.ApiCaller;
+import bot.api.ApiResponse;
+import bot.domain.contest.StandingsResponse;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.*;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.*;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ContestTimerHandler extends ListenerAdapter {
+    private final Map<String, ScheduledExecutorService> activeTimers = new HashMap<>();
+    private final Logger logger = LoggerFactory.getLogger(ContestTimerHandler.class);
+    private static final String BASE_URL = "https://codeforces.com/api/";
+    private static final Gson gson = new Gson();
+    private final ApiCaller apiCaller;
+
+    public ContestTimerHandler(ApiCaller apiCaller) {
+        this.apiCaller = apiCaller;
+    }
+
+    @Override
+    public void onButtonInteraction(ButtonInteractionEvent event) {
+        String componentId = event.getComponentId();
+
+        if (componentId.equals("confirm_contest")) {
+            logger.info("Confirm contest button clicked");
+            handleConfirmContest(event);
+        } else if (componentId.equals("cancel_contest")) {
+            logger.info("Cancel contest button clicked");
+            handleCancelContest(event);
+        }
+    }
+
+    private void handleConfirmContest(ButtonInteractionEvent event) {
+        Message message = event.getMessage();
+        EmbedBuilder embed = new EmbedBuilder(message.getEmbeds().getFirst());
+
+        // Get user time from the embed field
+        String startTimeStr = embed.getFields().stream()
+                .filter(field -> Objects.requireNonNull(field.getName()).contains("Virtual Start Time"))
+                .findFirst()
+                .map(MessageEmbed.Field::getValue)
+                .orElseThrow();
+
+        // Parse the start time
+        ZonedDateTime startTime = parseDateTime(startTimeStr);
+        if (startTime == null) {
+            event.reply("Error parsing the start time. Please check the format.").setEphemeral(true).queue();
+            return;
+        }
+
+        // Disable buttons
+        List<Button> updatedButtons = message.getButtons().stream()
+                .map(Button::asDisabled)
+                .toList();
+
+        // Edit the message to disable the buttons
+        message.editMessageComponents(
+                Collections.singletonList(ActionRow.of(updatedButtons))
+        ).queue();
+
+
+        // Example: "2 hours 25 minutes"
+        String duration = embed.getFields().stream()
+                .filter(field -> Objects.requireNonNull(field.getName()).contains("Duration"))
+                .findFirst()
+                .map(MessageEmbed.Field::getValue)
+                .orElseThrow();
+
+        // Parse the duration
+        String[] durationParts = duration.split(" ");
+        long hours = Long.parseLong(durationParts[0]);
+        long minutes = Long.parseLong(durationParts[2]);
+        Duration originalDuration = Duration.ofHours(hours).plusMinutes(minutes);
+
+        ZonedDateTime now = ZonedDateTime.now(startTime.getZone());
+        Duration timeUntilStart = Duration.between(now, startTime);
+        Duration totalDuration = timeUntilStart.plus(originalDuration);
+
+        long totalDurationSeconds = totalDuration.getSeconds();
+
+
+        String participantsStr = embed.getFields().stream()
+                .filter(field -> Objects.requireNonNull(field.getName()).contains("Participants"))
+                .findFirst()
+                .map(MessageEmbed.Field::getValue)
+                .orElseThrow();
+        logger.info("Participants: {}", participantsStr);
+
+        // Extract usernames using regex
+        List<String> usernames = new ArrayList<>();
+        Pattern pattern = Pattern.compile("`([^`]+)`");
+        Matcher matcher = pattern.matcher(participantsStr);
+        while (matcher.find()) {
+            usernames.add(matcher.group(1));
+        }
+        logger.info("Usernames: {}", usernames);
+
+        String contestId = embed.getFields().stream()
+                .filter(field -> Objects.requireNonNull(field.getName()).contains("Contest ID"))
+                .findFirst()
+                .map(MessageEmbed.Field::getValue)
+                .orElseThrow();
+
+        String contestTitle = embed.getFields().stream()
+                .filter(field -> Objects.requireNonNull(field.getName()).contains("Contest Name"))
+                .findFirst()
+                .map(MessageEmbed.Field::getValue)
+                .orElseThrow();
+
+        contestTitle = contestTitle.substring(1, contestTitle.indexOf("]"));
+
+        // Schedule the timer
+        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+        String finalContestTitle = contestTitle;
+        scheduler.schedule(() -> displayResults(event.getChannel(), contestId, finalContestTitle, usernames), totalDurationSeconds, TimeUnit.SECONDS);
+
+        // Store the scheduler for potential cancellation
+        activeTimers.put(contestId, scheduler);
+
+        // After confirmation, send the same embed visible to all
+        event.getChannel().sendMessageEmbeds(embed.build()).queue(); // Send to all users
+
+        event.reply("Contest confirmed! Results will be displayed after the contest ends.").setEphemeral(true).queue();
+    }
+
+    private ZonedDateTime parseDateTime(String dateTimeStr) {
+        try {
+            // Parse the date and time part
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMMM d, yyyy, h:mm a", Locale.ENGLISH);
+            LocalDateTime localDateTime = LocalDateTime.parse(dateTimeStr.substring(0, dateTimeStr.lastIndexOf(" ")), formatter);
+
+            // Parse the timezone offset
+            String offsetStr = dateTimeStr.substring(dateTimeStr.lastIndexOf(" ") + 1);
+            ZoneOffset offset = ZoneOffset.of(offsetStr);
+
+            // Combine into ZonedDateTime
+            return ZonedDateTime.of(localDateTime, offset);
+        } catch (DateTimeParseException e) {
+            logger.error("Error parsing date time: {}", dateTimeStr, e);
+            return null;
+        }
+    }
+
+
+    private void handleCancelContest(ButtonInteractionEvent event) {
+        Message message = event.getMessage();
+        EmbedBuilder embed = new EmbedBuilder(message.getEmbeds().getFirst());
+
+        String contestId = embed.getFields().stream()
+                .filter(field -> Objects.requireNonNull(field.getName()).contains("Contest ID"))
+                .findFirst()
+                .map(MessageEmbed.Field::getValue)
+                .orElseThrow();
+
+
+        // Cancel the timer
+        ScheduledExecutorService scheduler = activeTimers.get(contestId);
+        if (scheduler != null) {
+            try (scheduler) {
+                scheduler.shutdownNow();
+                activeTimers.remove(contestId);
+            }
+        } else {
+            logger.error("No active timer found for contest ID: {}", contestId);
+        }
+
+        event.reply("Contest cancelled!").setEphemeral(true).queue();
+
+        // Delete the message
+        message.delete().queue();
+    }
+
+
+    public void displayResults(MessageChannel channel, String contestId, String contestName, List<String> participants) {
+        CompletableFuture.supplyAsync(() -> {
+            try {
+                return contestTournamentResult(participants, contestId, contestName);
+            } catch (IOException e) {
+                logger.error("Error getting contest results", e);
+                return null;
+            }
+        }).thenAccept(embedBuilder -> {
+            if (embedBuilder != null) {
+                channel.sendMessageEmbeds(embedBuilder.build()).queue();
+            }
+        });
+    }
+
+
+    public EmbedBuilder contestTournamentResult(List<String> participants, String contestId, String contestName) throws IOException {
+        // Build the URL for the API call
+        StringBuilder url = new StringBuilder(BASE_URL + "contest.standings?contestId=" + contestId + "&asManager=false&handles=");
+        for (String username : participants) {
+            url.append(username).append(";");
+        }
+        url.deleteCharAt(url.length() - 1);
+        url.append("&showUnofficial=true");
+
+        // Make the API call
+        String jsonResponse = apiCaller.makeApiCall(url.toString());
+
+        // Parse the JSON response
+        Type responseType = new TypeToken<ApiResponse<StandingsResponse>>() {
+        }.getType();
+        ApiResponse<StandingsResponse> apiResponse = gson.fromJson(jsonResponse, responseType);
+
+        // Check if the response is OK
+        if (!"OK".equals(apiResponse.getStatus()) || apiResponse.getResult() == null) {
+            throw new IOException("Failed to retrieve contest standings");
+        }
+
+        // Extract the required information
+        StandingsResponse standings = apiResponse.getResult();
+        List<StandingsResponse.StandingsRow> rows = standings.getRows();
+
+        // Sort rows by rank
+        rows.sort(Comparator.comparingInt(StandingsResponse.StandingsRow::getRank));
+
+        return buildResult(contestId, contestName, rows);
+    }
+
+    @NotNull
+    private static EmbedBuilder buildResult(String contestId, String contestName, List<StandingsResponse.StandingsRow> rows) {
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+        embedBuilder.setTitle("Contest Results: " + contestName, "https://codeforces.com/contest/" + contestId);
+        embedBuilder.setDescription("Contest ID: " + contestId);
+        embedBuilder.setColor(Color.BLUE);
+
+        int index = 0;
+        for (StandingsResponse.StandingsRow row : rows) {
+            String username = row.getParty().getMembers().getFirst().getHandle();
+            String usernameLink = "[`" + username + "`](https://codeforces.com/profile/" + username + ")";
+            int rank = row.getRank();
+            int problemsSolved = 0;
+            int wrongAnswers = 0;
+
+            for (StandingsResponse.ProblemResult problemResult : row.getProblemResults()) {
+                if (problemResult.getPoints() > 0) {
+                    problemsSolved++;
+                }
+                wrongAnswers += problemResult.getRejectedAttemptCount();
+            }
+
+            String funnyWords = "";
+            index++;
+            if (index == 1) {
+                funnyWords = ":trophy: **Champion!**";
+            } else if (index <= 3) {
+                funnyWords = ":medal: **Top 3, impressive!**";
+            } else {
+                funnyWords = ":muscle: **Keep trying!**";
+            }
+            embedBuilder.addField("Username", usernameLink + "\t" + funnyWords, true);
+            embedBuilder.addField("Rank", String.valueOf(rank), false);
+            embedBuilder.addField("Problems Solved", String.valueOf(problemsSolved), false);
+            embedBuilder.addField("Wrong Answers", String.valueOf(wrongAnswers), false);
+        }
+        return embedBuilder;
+    }
+}

--- a/src/main/java/bot/listener/DiscordEventListener.java
+++ b/src/main/java/bot/listener/DiscordEventListener.java
@@ -4,6 +4,7 @@ import bot.CodeforcesBot;
 import bot.commands.Command;
 import bot.commands.CommandFactory;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.session.ReadyEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
@@ -67,6 +68,9 @@ public class DiscordEventListener extends ListenerAdapter {
     public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
         Command command = CommandFactory.getCommand(event.getName());
         if (command != null) {
+            // Log the user who used the command
+//            logger.info("Command used by: " + event.getUser().getName() + " (ID: " + event.getUser().getId() + ")");
+
             command.execute(event);
         } else {
             event.reply("Unknown command").queue();
@@ -76,4 +80,20 @@ public class DiscordEventListener extends ListenerAdapter {
     public void resetGuildCommands(@NotNull ShardManager shardManager, String guildId) {
         Objects.requireNonNull(shardManager.getGuildById(guildId)).updateCommands().queue();
     }
+
+//    @Override
+//    public void onMessageReceived(MessageReceivedEvent event) {
+//        logger.info("Server name: " + event.getGuild().getName()
+//                    + " Server ID: " + event.getGuild().getId()
+//                    + " Channel: " + event.getChannel()
+//                    + " User: " + event.getAuthor()
+//                    + " Message: " + event.getMessage().getContentDisplay()
+//                    + " Message ID: " + event.getMessageId()
+//                    + event.getMember());
+//
+//        /*
+//        Output example:
+//         Server name: am0103738 Server ID: 423085629807788032 Channel: TextChannel:general(id=423085629807788034) User: SelfUser:test-Codeforces bot(id=1284923117948370977) Message:  Message ID: 1284943171234828412Member:test-Codeforces bot(id=1284923117948370977, user=SelfUser:test-Codeforces bot(id=1284923117948370977), guild=Guild:am0103738(id=423085629807788032))
+//         */
+//    }
 }


### PR DESCRIPTION
Feature: Random Contest Suggestion Command

Implemented a new command that suggests a random contest of a specified type (like Div 1, 2, 3, etc.) for users. The contest will be one that none of the given usernames have participated in before.

After the virtual contest ends, the bot will send the participants' ranks along with details like:

- Number of solved problems
- Number of wrong answers during the contest

Example command: `/random-contest usernames: _AhmedMohamed_, Shayan contest_type: div3 start_time: 2024-09-16 07:37:00 +03:00`

The bot can handle multiple time zones correctly. The user can also confirm or cancel the command using buttons.

![image](https://github.com/user-attachments/assets/bdf178bb-ad8d-400a-af31-1c287dc6e5d0)
![image](https://github.com/user-attachments/assets/dc3589c5-2c88-4ee8-85a1-08b8b25201c0)
![image](https://github.com/user-attachments/assets/599868d4-052f-4af4-b797-2e683e2c50e0)
